### PR TITLE
supports Object#to_json options

### DIFF
--- a/.console_history
+++ b/.console_history
@@ -1,0 +1,100 @@
+a.data.map{|d| d.to_tsv}
+a.data(Date.today - 1.week, Date.today).map{|d| d.to_tsv}
+a.data(Date.today - 1.week, Date.today).map{|d| d.to_tsv} * "\r"
+pp
+pp a.data(Date.today - 1.week, Date.today).map{|d| d.to_tsv} * "\r"
+a.title
+pp a.data(Date.today - 1.week, Date.today).map{|d| d.to_tsv}
+pp a.fetch_data(Date.today - 1.week, Date.today)
+a.data_points.last
+a.data_points
+p = Sources::GoogleAnalytics::Profile.new(email: 'coreybantik@gmail.com', password: '$amura!23')
+a = p.accounts.last
+p = Sources::GoogleAnalytics::Report.new(email: 'coreybantik@gmail.com', password: '$amura!23')
+p.report
+a = Sources::GoogleAnalytics::Account.new(email: 'coreybantik@gmail.com', password: '$amura!23')
+a = Sources::GoogleAnalytics::Account.find(email: 'coreybantik@gmail.com', password: '$amura!23', '1')
+a = Sources::GoogleAnalytics::Account.find('coreybantik@gmail.com','$amura!23123123', '1')
+a = Sources::GoogleAnalytics::Account.find('coreybantik@gmail.com','$amura!23', '1')
+a = Sources::GoogleAnalytics::Account.all('coreybantik@gmail.com','$amura!23')
+a.profiles
+a.email
+a.profile
+a = Sources::GoogleAnalytics::Account.find('coreybantik@gmail.com','$amura!23', 676985)
+a = Sources::GoogleAnalytics::Account.all
+a = Sources::GoogleAnalytics::Account.all('coreybantik@gmail.com', '$amura!23')
+aa = _
+a = aa.first
+puts "FOO" unless bar = nil
+puts "FOO" unless (bar = nil)
+c = Sources::GoogleAnalytics::Connector.new
+c = Sources::GoogleAnalytics::Connector.new(:email => 'coreybantik@gmail.com')
+c = Sources::GoogleAnalytics::Connector.new(:email => 'coreybantik@gmail.com', :password => '$amura!23'))
+c = Object.new
+c.inspect
+c.to_s
+c.accounts
+a = _.first
+a = c.accounts.first
+c.accounts.where(:profile_id => 45149121)
+c.accounts.where(:profile_id => 45149121).first
+a = _
+r.account
+c.pasword
+c.password
+a.repoert
+a.report
+a.report.data
+a.password
+a = c.accounts.where(:profile_id => 45149121).first; return nil
+r.profile_id
+r.fetch_data
+c = Sources::GoogleAnalytics::Connector.new(:email => 'coreybantik@gmail.com', :password => '$amura!23'); nil
+a = c.accounts.where(:profile_id => 45149121).first; nil
+relaod!
+SearchQuery::Property.new
+q = _
+exot
+q = SearchQuery::Property.new
+q = SearchQuery::Property.new; q.foo
+q = SearchQuery::Property.new; q.page
+q = SearchQuery::Property.new(:page = 1)
+q.page
+q.execute!
+q.instance_variables
+q = SearchQuery::Property.new(:page => 1)
+q.to_attributes
+include Searchable
+reload!
+searches 'SearchResult::Detail'
+Foo.searches
+c = Sources::GoogleAnalytics::Connector.new(:email => 'coreybantik@gmail.com', :password => '$amura!23')
+c
+a = c.accounts.where(:profile_id => 45149121).first
+r = a.report
+r.data
+r.to_tsv
+require 'json'
+{:foo => 'bar'}.to_json
+f.public_send(:bar => 1)
+class Foo
+def bar
+puts "OL"
+f = Foo.new
+f.public_send(:foo)
+f.public_send(:bar)
+require 'version'
+require 'poro_plus/version'
+require 'poro_plus'
+PoroPlus
+      include PoroPlus
+      attr_accessor :foo, :bar
+    end
+thing_one = MyThing.new(:foo => 'Raven', :bar => 'Writing Desk')
+thing_one.to_hash
+class MyThing
+      attr_accessor :foo, :bar, :tres
+end
+thing_one = MyThing.new(:foo => 'Raven', :bar => 'Writing Desk', :tres => nil)
+thing_one.to_json(:skip_nils => true)
+exit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in poro_plus.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    poro_plus (1.0.1)
+    poro_plus (1.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    poro_plus (1.0.0)
+    poro_plus (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,27 @@
+PATH
+  remote: .
+  specs:
+    poro_plus (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.4)
+    rake (10.1.0)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.3)
+  poro_plus!
+  rake
+  rspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2013 Bantik
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,44 @@
-poro_plus
-=========
-
+# PoroPlus
 Friendly methods intended to make POROs more useful.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'poro_plus'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install poro_plus
+
+## Usage
+
+Simply include PoroPlus into your Ruby class:
+
+    class MyThing
+      include PoroPlus
+      attr_accessor :foo, :bar, :tres
+    end
+
+Then you can:
+
+    > thing_1 = MyThing.new(:foo => 'Raven', :bar => 'Writing Desk', :tres => nil)
+    => #<MyThing:0x007ff4866ea398 @foo="Raven", @bar="Writing Desk", @tres=nil>
+
+    > thing_1.to_hash
+    => {:foo=>"Raven", :bar=>"Writing Desk", :tres=>nil}
+
+    > thing_one.to_json(:skip_nils => true)
+     => "{\"foo\":\"Raven\",\"bar\":\"Writing Desk\"}"
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+poro_plus
+=========
+
+Friendly methods intended to make POROs more useful.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+#!/usr/bin/env rake
+require "bundler/gem_tasks"
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'lib/bramipsum'
+  t.test_files = FileList['test/lib/poro_plus/*_test.rb']
+  t.verbose = true
+end
+
+task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,2 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
-
-require 'rake/testtask'
-
-Rake::TestTask.new do |t|
-  t.libs << 'lib/bramipsum'
-  t.test_files = FileList['test/lib/poro_plus/*_test.rb']
-  t.verbose = true
-end
-
-task :default => :test

--- a/lib/poro_plus.rb
+++ b/lib/poro_plus.rb
@@ -1,0 +1,28 @@
+require 'json'
+
+module PoroPlus
+
+  def initialize(args={})
+    args.each{|k,v| self.public_send("#{k}=", v) if self.respond_to?("#{k}=")}
+  end
+
+  def to_hash(args={})
+    instance_variables.inject({}) do |h, iv|
+      value = instance_variable_get(iv)
+      return h if value.nil? && args[:skip_nils]
+      h[sanitized_key(iv)] = value
+      h
+    end
+  end
+
+  def to_json(args={})
+    to_hash(args).to_json
+  end
+
+  private
+
+  def sanitized_key(instance_variable_name)
+    instance_variable_name.to_s.gsub('@','').to_sym
+  end
+
+end

--- a/lib/poro_plus.rb
+++ b/lib/poro_plus.rb
@@ -16,7 +16,7 @@ module PoroPlus
   end
 
   def to_json(args={})
-    to_hash(args).to_json
+    to_hash(args).to_json(args.tap { |hs| hs.delete(:skip_nils) })
   end
 
   private

--- a/lib/poro_plus/version.rb
+++ b/lib/poro_plus/version.rb
@@ -1,0 +1,3 @@
+module PoroPlus
+  VERSION='1.0.0'
+end

--- a/lib/poro_plus/version.rb
+++ b/lib/poro_plus/version.rb
@@ -1,3 +1,3 @@
 module PoroPlus
-  VERSION='1.0.0'
+  VERSION='1.0.1'
 end

--- a/lib/poro_plus/version.rb
+++ b/lib/poro_plus/version.rb
@@ -1,3 +1,3 @@
 module PoroPlus
-  VERSION='1.0.1'
+  VERSION='1.0.2'
 end

--- a/poro_plus.gemspec
+++ b/poro_plus.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["corey@idolhands.com"]
   spec.description   = %q{Simple methods to make POROs more fun.}
   spec.summary       = %q{Simple methods to make Plain Old Ruby Objects (POROs) more fun.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/Bantik/poro_plus"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)

--- a/poro_plus.gemspec
+++ b/poro_plus.gemspec
@@ -1,0 +1,25 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'poro_plus/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "poro_plus"
+  spec.version       = PoroPlus::VERSION
+  spec.authors       = ["Bantik"]
+  spec.email         = ["corey@idolhands.com"]
+  spec.description   = %q{Simple methods to make POROs more fun.}
+  spec.summary       = %q{Simple methods to make Plain Old Ruby Objects (POROs) more fun.}
+  spec.homepage      = ""
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+end

--- a/spec/lib/poro_plus/poro_plus_spec.rb
+++ b/spec/lib/poro_plus/poro_plus_spec.rb
@@ -23,7 +23,7 @@ describe PoroPlus do
       thing.to_hash[:bar].should == 2
     end
 
-    it 'nil-values are not skipped normally' do 
+    it 'nil-values are not skipped normally' do
       thing = Thing.new(foo: 1, bar: nil)
       thing.to_hash[:foo].should == 1
       thing.to_hash[:bar].should be_nil
@@ -35,7 +35,7 @@ describe PoroPlus do
     end
 
   end
- 
+
   describe '#to_json' do
     it "converts its instance variables to json string" do
       thing = Thing.new(foo: 1, bar: 2)
@@ -50,6 +50,11 @@ describe PoroPlus do
     it 'skips nil-value instance variables if so configured with skip_nils flag' do
       thing = Thing.new(foo: 1, bar: nil)
       thing.to_json(:skip_nils => true).should == "{\"foo\":1}"
+    end
+
+    it "accepts 'Object#to_json' options and utilize them" do
+      thing = Thing.new(foo: 1, bar: nil)
+      thing.to_json(skip_nils: true, indent: "\t").should eq("{\t\"foo\":1}")
     end
 
   end

--- a/spec/lib/poro_plus/poro_plus_spec.rb
+++ b/spec/lib/poro_plus/poro_plus_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe PoroPlus do
+
+  class Thing
+    include PoroPlus
+    attr_accessor :foo
+    attr_accessor :bar
+  end
+
+  describe '#sanitized_key' do
+    it 'converts a @foo-style instance variable to a symbol' do
+      thing = Thing.new
+      thing.send(:sanitized_key, "@foo_bar").should == :foo_bar
+    end
+  end
+
+  describe '#to_hash' do
+
+    it 'serializes its instance variables' do
+      thing = Thing.new(:foo => 1, :bar => 2)
+      thing.to_hash[:foo].should == 1
+      thing.to_hash[:bar].should == 2
+    end
+
+    it 'skips nil-value instance variables if so configured' do
+      thing = Thing.new(:foo => 1, :bar => nil)
+      thing.to_hash(:skip_nils => true).keys.include?(:bar).should be_false
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'rubygems'
+require 'bundler/setup'
+require 'poro_plus'


### PR DESCRIPTION
<code>[to_json](http://www.ruby-doc.org/stdlib-2.0/libdoc/json/rdoc/JSON.html)</code> is implemented by some core classes of Ruby and has its [option](http://www.ruby-doc.org/stdlib-2.0/libdoc/json/rdoc/JSON/Ext/Generator/State.html#new-method), which the gem does not currently support, this might be confusing to an end user who wants to use the gem in a project and still requires the default <code>to_json</code> behavior