### PR TITLE
Allow methods to override nil initialized values

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at coraline@idolhands.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,26 @@
 PATH
   remote: .
   specs:
-    poro_plus (1.1.5)
+    poro_plus (1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    rake (10.1.0)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    diff-lcs (1.3)
+    rake (12.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
 
 PLATFORMS
   ruby
@@ -27,4 +32,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -32,8 +32,28 @@ Then you can:
     > thing_1.to_hash
     => {:foo=>"Raven", :bar=>"Writing Desk", :tres=>nil}
 
-    > thing_one.to_json(:skip_nils => true)
+    > thing_1.to_json(:skip_nils => true)
      => "{\"foo\":\"Raven\",\"bar\":\"Writing Desk\"}"
+
+If you want the JSON to include methods that return values:
+
+    class MyThing
+      include PoroPlus
+      attr_reader :foo, :bar, :tres
+
+      def tres
+        "tres leches con #{self.bar}"
+      end
+
+    end
+
+Then, passing a nil to create a placeholder for that JSON attribute, you can:
+
+    > thing_2 = MyThing.new(:foo => 'Taco', :bar => 'cinnammon', :tres => nil) # nil placeholder
+    => #<MyThing:0x007ff4866ea398 @foo="Taco", @bar="cinnammon", @tres=nil>
+
+    > thing_2.to_json(:skip_nils => true)
+     => "{\"foo\":\"Taco\",\"bar\":\"cinnammon\",\"tres\":\"tres leches con cinnammon\"}"
 
 ## Contributing
 

--- a/lib/poro_plus.rb
+++ b/lib/poro_plus.rb
@@ -8,7 +8,9 @@ module PoroPlus
 
   def to_hash(args={})
     instance_variables.inject({}) do |h, iv|
+      key = sanitized_key(iv)
       value = instance_variable_get(iv)
+      value ||= self.public_send(key) if self.respond_to?(key)
       return h if value.nil? && args[:skip_nils]
       h[sanitized_key(iv)] = value
       h

--- a/lib/poro_plus/version.rb
+++ b/lib/poro_plus/version.rb
@@ -1,3 +1,3 @@
 module PoroPlus
-  VERSION='1.1.5'
+  VERSION='1.2'
 end

--- a/spec/lib/poro_plus/poro_plus_spec.rb
+++ b/spec/lib/poro_plus/poro_plus_spec.rb
@@ -6,6 +6,11 @@ describe PoroPlus do
     include PoroPlus
     attr_accessor :foo
     attr_accessor :bar
+    attr_reader :baz
+
+    def baz
+      foo + bar
+    end
   end
 
   describe '#sanitized_key' do
@@ -23,7 +28,7 @@ describe PoroPlus do
       thing.to_hash[:bar].should == 2
     end
 
-    it 'nil-values are not skipped normally' do 
+    it 'nil-values are not skipped normally' do
       thing = Thing.new(foo: 1, bar: nil)
       thing.to_hash[:foo].should == 1
       thing.to_hash[:bar].should be_nil
@@ -31,11 +36,11 @@ describe PoroPlus do
 
     it 'skips nil-value instance variables if so configured with skip_nils flag' do
       thing = Thing.new(foo: 1, bar: nil)
-      thing.to_hash(:skip_nils => true).keys.include?(:bar).should be_false
+      thing.to_hash(:skip_nils => true).keys.include?(:bar).should be_falsey
     end
 
   end
- 
+
   describe '#to_json' do
     it "converts its instance variables to json string" do
       thing = Thing.new(foo: 1, bar: 2)
@@ -54,5 +59,11 @@ describe PoroPlus do
 
   end
 
-end
+  context "with overriding methods" do
+    it "replaces a nil initialized value with a method call" do
+      thing = Thing.new(foo: 1, bar: 2, baz: nil)
+      thing.to_json.should == "{\"foo\":1,\"bar\":2,\"baz\":3}"
+    end
+  end
 
+end


### PR DESCRIPTION
## Problem
You can't add a method to a PoroPlus object that overrides its initialized value.

## Solution
Try to grab the value off the instance variable, and if nil, call the associated method.